### PR TITLE
Read SOF byte-by-byte to allow resync

### DIFF
--- a/library/pms5003/__init__.py
+++ b/library/pms5003/__init__.py
@@ -124,7 +124,7 @@ class PMS5003():
 
             sof = self._serial.read(1)
             if len(sof) == 0:
-                raise SerialTiemoutError("PMS5003 Read Timeout: Failed to read start of frame byte")
+                raise SerialTimeoutError("PMS5003 Read Timeout: Failed to read start of frame byte")
             sof = ord(sof) if type(sof) is bytes else sof
 
             if sof == PMS5003_SOF[sof_index]:


### PR DESCRIPTION
As suggested by @nophead in #3 this change reads the PMS5003 start-of-frame marker one byte at a time, so in the instance where the sensor is completely out of sync, it doesn't discard possibly valid initial bytes.

In the original setup 2 bytes would be read at a time. It was entirely possible for this to be one invalid  byte, plus one valid first byte to the SOF. Since this first byte had now been read and discarded, the next read would contain the second byte first, and one garbage byte. The result- the PMS5003 never gets back into sync.

By reading 1 byte at a time we no longer discard potentially valid SOF bytes.

This aims to fix: https://github.com/pimoroni/pms5003-python/issues/4
And possibly also: https://github.com/pimoroni/pms5003-python/issues/3
And may relate to: https://github.com/pimoroni/pms5003-python/issues/2
