### PR TITLE
Add dict interface

### DIFF
--- a/examples/telegraf_influxdb.py
+++ b/examples/telegraf_influxdb.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""
+Call this script from telegraf by adding the following lines to telegraf.conf
+
+[[inputs.exec]]
+  commands = ["python <script location>/telegraf_influxdb.py"]
+  timeout = "2s"
+  data_format = "influx"
+"""
+
+from pms5003 import PMS5003
+
+
+# Configure the PMS5003 for Enviro+
+pms5003 = PMS5003(
+    device='/dev/ttyAMA0',
+    baudrate=9600,
+    pin_enable=22,
+    pin_reset=27
+)
+
+print(pms5003.read().as_influxdb_line_proto())

--- a/library/pms5003/__init__.py
+++ b/library/pms5003/__init__.py
@@ -95,7 +95,7 @@ class PMS5003Data():
         Get the data in the form of influxDB line protocol
         :return: str: the formatted data
         """
-        ret = [f"{meas_name},size={x['size']},environment={'environment'} pm={x['val']}" for x in self.get_all_pm()]
+        ret = [f"{meas_name},size={x['size']},environment={x['environment']} pm={x['val']}" for x in self.get_all_pm()]
         ret.extend([f"{meas_name},size={s} count={c}" for s, c in self.get_all_counts().items()])
         if timestamp:
             ret = [x + f' {self.timestamp}' for x in ret]

--- a/library/pms5003/__init__.py
+++ b/library/pms5003/__init__.py
@@ -95,8 +95,8 @@ class PMS5003Data():
         Get the data in the form of influxDB line protocol
         :return: str: the formatted data
         """
-        ret = [f"{meas_name},size={x['size']},environment={x['environment']} pm={x['val']}" for x in self.get_all_pm()]
-        ret.extend([f"{meas_name},size={s} count={c}" for s, c in self.get_all_counts().items()])
+        ret = [f"{meas_name},size={x['size']},environment={x['environment']} pm={x['val']}u" for x in self.get_all_pm()]
+        ret.extend([f"{meas_name},size={s} count={c}u" for s, c in self.get_all_counts().items()])
         if timestamp:
             ret = [x + f' {self.timestamp}' for x in ret]
         return '\n'.join(ret)

--- a/library/pms5003/__init__.py
+++ b/library/pms5003/__init__.py
@@ -63,6 +63,25 @@ class PMS5003Data():
 
         raise ValueError("Particle size {} measurement not available.".format(size))
 
+    def get_all_pm(self):
+        """
+        Returns all PM measurements as a list of dicts with keys 'size', 'environment', and 'val' which are the
+        particulate matter size recorded by the measurement, the conditions this was calculated under (atmospheric or
+        standard) and the actual value of the PM measurement in ug/m^3
+
+        :return: list of dicts of measurements
+        """
+        vals = [{'size': x, 'environment': y} for y in ['std', 'atm'] for x in [1.0, 2.5, 10.0]]
+        return [{k: v for d in (x, {'val': y}) for (k, v) in d.items()} for x, y in zip(vals, self.data)]
+
+    def get_all_counts(self):
+        """
+        Returns dict mapping size (float) to number (int) of particles beyond that size in 0.1 L of air.
+        :return: dict: size -> particle count
+        """
+        sizes = [0.3, 0.5, 1.0, 2.5, 5.0, 10.0]
+        return {s: v for s, v in zip(sizes, self.data[6:])}
+
     def __repr__(self):
         return """
 PM1.0 ug/m3 (ultrafine particles):                             {}
@@ -81,6 +100,16 @@ PM10 ug/m3 (atmos env):                                        {}
 
     def __str__(self):
         return self.__repr__()
+
+    def __iter__(self):
+        """
+        Iterator allows conversion of data object into dict for direct access. IE call d = dict(data)
+        :return:
+        """
+        for x in self.get_all_pm():
+            yield "pm{:.1f}_{:s}".format(x['size'], x['environment']), x['val']
+        for size, count in self.get_all_counts().items():
+            yield "count_{:.1f}".format(size), count
 
 
 class PMS5003():

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pms5003
-version = 0.0.5
+version = 0.0.6
 author = Philip Howard
 author_email = phil@pimoroni.com
 description = PMS5003 Particulate Sensor

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -60,6 +60,7 @@ def test_read():
     data.get_all_pm()
     data.get_all_counts()
     dict(data)
+    data.as_influxdb_line_proto()
 
 
 def test_read_fail():

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -57,6 +57,9 @@ def test_read():
     sensor._serial = MockSerial()
     data = sensor.read()
     data.pm_ug_per_m3(2.5)
+    data.get_all_pm()
+    data.get_all_counts()
+    dict(data)
 
 
 def test_read_fail():


### PR DESCRIPTION
Hey folks, for my application I added some methods that provide aggregate output from the data class. The added methods are:

- `get_all_pm` - Returns all PM measurements as a list of dicts that contain the values and tags associated with measurements
- `get_all_counts` - Returns the particle counts as a dict where the key is particle size
- `as_influxdb_line_proto` - Represents the data as a string in the format of influxdb line protocol.
- `__iter__` - allows the class to be converted into a dict by calling `dict(data)`. This may help resolve what is asked for in issue #15 

These are useful for my use case of calling this package and outputting the data into an influxdb database using telegraf. I was able to test everything on my raspberry pi and I am receiving data. I thought that I'd offer the changes here if you think they should be part of the package.